### PR TITLE
Fixes.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,11 +1,25 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="99" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="99" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <ScalaCodeStyleSettings>
-      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
-    </ScalaCodeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </state>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,6 +7,9 @@
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.1.0"
+version = "0.1.2"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     }
     testImplementation("io.mockk:mockk:1.10.3-jdk8")
 
-    implementation(group = "org.openjdk.jmh", name = "jmh-core", version = "1.26")
+    jmhImplementation(group = "org.openjdk.jmh", name = "jmh-core", version = "1.26")
 }
 
 tasks {

--- a/src/main/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucket.kt
@@ -61,11 +61,11 @@ class ArgumentBucket(
     }
 
     override val entries: Set<Map.Entry<KParameter, Any?>>
-        get() = keys.fold(HashSet()) { acc, cur ->
+        get() = keyList.fold(HashSet()) { acc, cur ->
             acc.apply { if (initializationStatuses[cur.index]) add(Entry(cur, valueArray[cur.index])) }
         }
     override val keys: Set<KParameter>
-        get() = keys.fold(HashSet()) { acc, cur ->
+        get() = keyList.fold(HashSet()) { acc, cur ->
             acc.apply { if (initializationStatuses[cur.index]) add(cur) }
         }
     override val size: Int get() = initializationStatuses.count { it }

--- a/src/main/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucket.kt
@@ -1,6 +1,5 @@
 package com.mapk.fastkfunction.argumentbucket
 
-import java.lang.UnsupportedOperationException
 import kotlin.reflect.KParameter
 
 class ArgumentBucket(
@@ -69,6 +68,7 @@ class ArgumentBucket(
         get() = keys.fold(HashSet()) { acc, cur ->
             acc.apply { if (initializationStatuses[cur.index]) add(cur) }
         }
+    override val size: Int get() = initializationStatuses.count { it }
     override val values: Collection<Any?>
         get() = valueArray.filterIndexed { idx, _ -> initializationStatuses[idx] }
 
@@ -82,8 +82,5 @@ class ArgumentBucket(
     override fun get(key: KParameter): Any? = valueArray[key.index]
     operator fun get(index: Int): Any? = valueArray[index]
 
-    // サイズ系の処理はVALUEパラメータ以外を考慮した際の整合性を考えることが難しく、使う場面も無いためUnsupported
-    override val size: Int
-        get() = throw UnsupportedOperationException()
-    override fun isEmpty(): Boolean = throw UnsupportedOperationException()
+    override fun isEmpty(): Boolean = size == 0
 }

--- a/src/test/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucketTest.kt
@@ -79,4 +79,18 @@ private class ArgumentBucketTest {
             }
         }
     }
+
+    @Test
+    fun entriesTest() {
+        assertTrue(bucket.entries.isEmpty())
+
+        bucket[0] = 0.toShort()
+        bucket[1] = 1
+
+        val entries = bucket.entries.sortedBy { it.key.index }
+        assertEquals(2, entries.size)
+        entries.forEach {
+            assertEquals(it.key.index, (it.value as Number).toInt())
+        }
+    }
 }

--- a/src/test/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucketTest.kt
@@ -96,6 +96,41 @@ private class ArgumentBucketTest {
     }
 
     @Test
+    fun keysTest() {
+        assertTrue(bucket.keys.isEmpty())
+
+        bucket[0] = 0.toShort()
+        val result = bucket.keys
+
+        assertEquals(1, result.size)
+        assertEquals(0, result.single().index)
+    }
+
+    @Test
+    fun valuesTest() {
+        assertTrue(bucket.isEmpty())
+
+        bucket[0] = null
+        bucket[1] = 100
+        val result = bucket.values
+
+        assertTrue(result.contains(null))
+        assertTrue(result.contains(100))
+    }
+
+    @Test
+    fun containsValueTest() {
+        assertFalse(bucket.containsValue(null))
+        assertFalse(bucket.containsValue(100))
+
+        bucket[0] = null
+        bucket[1] = 100
+
+        assertTrue(bucket.containsValue(null))
+        assertTrue(bucket.containsValue(100))
+    }
+
+    @Test
     fun isEmptyTest() {
         assertTrue(bucket.isEmpty())
 

--- a/src/test/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/mapk/fastkfunction/argumentbucket/ArgumentBucketTest.kt
@@ -1,6 +1,7 @@
 package com.mapk.fastkfunction.argumentbucket
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
@@ -92,5 +93,14 @@ private class ArgumentBucketTest {
         entries.forEach {
             assertEquals(it.key.index, (it.value as Number).toInt())
         }
+    }
+
+    @Test
+    fun isEmptyTest() {
+        assertTrue(bucket.isEmpty())
+
+        bucket[0] = 0.toShort()
+
+        assertFalse(bucket.isEmpty())
     }
 }


### PR DESCRIPTION
## build.gradle.ktsの修正
- `jmh`関連のライブラリが配布物に含まれていた問題の修正

## ArgumentBucketの修正
- `ArgumentBucket`の`size`系プロパティを`override`しておらず、デバッガがエラーを吐いていた問題の修正
- `keys`/`entries`が循環参照を起こしており、エラーになる問題の修正
- 不足していたテストの追加